### PR TITLE
Fix wrong smear placement with concealed characters

### DIFF
--- a/lua/smear_cursor/animation.lua
+++ b/lua/smear_cursor/animation.lua
@@ -6,11 +6,17 @@ local screen = require("smear_cursor.screen")
 local M = {}
 
 
-local cursor_row, cursor_col = screen.get_screen_cursor_position()
-local target_position = {cursor_row + 1, cursor_col + 1} -- Not sure why +1 is needed
-local current_position = {target_position[1], target_position[2]}
-local trailing_position = {target_position[1], target_position[2]}
+local target_position = {0, 0}
+local current_position = {0, 0}
+local trailing_position = {0, 0}
 local animating = false
+
+vim.defer_fn(function()
+	local cursor_row, cursor_col = screen.get_screen_cursor_position()
+	target_position = {cursor_row, cursor_col}
+	current_position = {cursor_row, cursor_col}
+	trailing_position = {cursor_row, cursor_col}
+end, 0)
 
 
 local function update()

--- a/lua/smear_cursor/draw.lua
+++ b/lua/smear_cursor/draw.lua
@@ -65,6 +65,7 @@ local function draw_character_floating_window(row, col, character, hl_group, L)
 			style = "minimal",
 			focusable = false,
 			noautocmd = true,
+			zindex = 300,
 		})
 		vim.api.nvim_win_set_option(window_id, "winhl", "Normal:Normal")
 

--- a/lua/smear_cursor/events.lua
+++ b/lua/smear_cursor/events.lua
@@ -8,7 +8,8 @@ local M = {}
 local switching_buffer = false
 
 
-M.move_cursor = function()
+
+local function move_cursor()
 	local row, col = screen.get_screen_cursor_position()
 	local jump = not config.smear_between_buffers and switching_buffer
 	animation.change_target_position(row, col, jump)
@@ -16,10 +17,18 @@ M.move_cursor = function()
 	switching_buffer = false
 end
 
+M.move_cursor = function()
+	vim.defer_fn(move_cursor, 0) -- for screen.get_screen_cursor_position()
+end
 
-M.jump_cursor = function()
+
+local function jump_cursor()
 	local row, col = screen.get_screen_cursor_position()
 	animation.change_target_position(row, col, true)
+end
+
+M.jump_cursor = function()
+	vim.defer_fn(jump_cursor, 0) -- for screen.get_screen_cursor_position()
 end
 
 

--- a/lua/smear_cursor/screen.lua
+++ b/lua/smear_cursor/screen.lua
@@ -4,7 +4,18 @@ local M = {}
 
 M.get_screen_cursor_position = function()
 	-- Must be called in a vim.defer_fn, otherwise it will return previous cursor position
-	return vim.fn.screenrow(), vim.fn.screencol()
+	local window_id = vim.api.nvim_get_current_win()
+	local window_info = vim.fn.getwininfo(window_id)[1]
+	local window_config = vim.api.nvim_win_get_config(window_id)
+	local row = vim.fn.screenrow()
+	local col = vim.fn.screencol()
+
+	if #window_config.relative > 0 then
+		row = row + window_info.winrow - 1
+		col = col + window_info.wincol - 1
+	end
+
+	return row, col
 end
 
 

--- a/lua/smear_cursor/screen.lua
+++ b/lua/smear_cursor/screen.lua
@@ -2,16 +2,9 @@ local logging = require("smear_cursor.logging")
 local M = {}
 
 
-M.get_screen_cursor_position = function(window_id)
-	window_id = window_id or vim.api.nvim_get_current_win()
-
-	local window_origin = vim.api.nvim_win_get_position(window_id)
-	local window_row = window_origin[1]
-	local window_col = window_origin[2]
-	local screen_row = window_row + vim.fn.winline()
-	local screen_col = window_col + vim.fn.wincol()
-
-	return screen_row, screen_col
+M.get_screen_cursor_position = function()
+	-- Must be called in a vim.defer_fn, otherwise it will return previous cursor position
+	return vim.fn.screenrow(), vim.fn.screencol()
 end
 
 


### PR DESCRIPTION
fixes #13

# Changed

- use `vim.fn.screenrow()` and `vim.fn.screencol()` to get cursor position


# Issues

- must use `vim.defer_fn`, otherwise past cursor position is returned, resulting in slower reaction time
- target cursor flickers more