### PR TITLE
refactor: window management

### DIFF
--- a/lua/smear_cursor/events.lua
+++ b/lua/smear_cursor/events.lua
@@ -39,7 +39,6 @@ M.listen = function()
 			autocmd CursorMoved * lua require("smear_cursor.events").move_cursor()
 			autocmd CursorMovedI,WinScrolled * lua require("smear_cursor.events").jump_cursor()
 			autocmd BufLeave * lua require("smear_cursor.events").flag_switching_buffer()
-			autocmd TabNew * lua require("smear_cursor.draw").initialize_lists()
 		augroup END
 	]],
 		false

--- a/lua/smear_cursor/init.lua
+++ b/lua/smear_cursor/init.lua
@@ -7,10 +7,6 @@ local M = {}
 local enabled = false
 
 local function initialize()
-	if _G.smear_cursor == nil then
-		_G.smear_cursor = {}
-	end
-	draw.initialize_lists()
 	events.listen()
 end
 


### PR DESCRIPTION
This PR builds further on the stylua PR:

- fixes issues with `:fclose!`, and other ways, where smear windows could become invalid
- it also uses the correct methods to set window/buffer options locally and without using deprecated APIs