### PR TITLE
perf: use blnd hl groups

### DIFF
--- a/lua/smear_cursor/color.lua
+++ b/lua/smear_cursor/color.lua
@@ -76,8 +76,8 @@ local function set_hl_groups()
 		local blended_hl_group_inverted = M.hl_group_inverted .. i
 		M.hl_groups[i] = blended_hl_group
 		M.hl_groups_inverted[i] = blended_hl_group_inverted
-		vim.api.nvim_set_hl(0, blended_hl_group, { fg = blended_cursor_color, bg = normal_bg })
-		vim.api.nvim_set_hl(0, blended_hl_group_inverted, { fg = normal_bg, bg = blended_cursor_color })
+		vim.api.nvim_set_hl(0, blended_hl_group, { fg = blended_cursor_color, bg = normal_bg, blend = 100 })
+		vim.api.nvim_set_hl(0, blended_hl_group_inverted, { fg = normal_bg, bg = blended_cursor_color, blend = 0 })
 	end
 end
 

--- a/lua/smear_cursor/color.lua
+++ b/lua/smear_cursor/color.lua
@@ -76,7 +76,7 @@ local function set_hl_groups()
 		local blended_hl_group_inverted = M.hl_group_inverted .. i
 		M.hl_groups[i] = blended_hl_group
 		M.hl_groups_inverted[i] = blended_hl_group_inverted
-		vim.api.nvim_set_hl(0, blended_hl_group, { fg = blended_cursor_color, bg = normal_bg, blend = 100 })
+		vim.api.nvim_set_hl(0, blended_hl_group, { fg = blended_cursor_color, bg = normal_bg, blend = 0 })
 		vim.api.nvim_set_hl(0, blended_hl_group_inverted, { fg = normal_bg, bg = blended_cursor_color, blend = 0 })
 	end
 end

--- a/lua/smear_cursor/draw.lua
+++ b/lua/smear_cursor/draw.lua
@@ -53,7 +53,7 @@ function M.get_win(tab, row, col)
 	local ei = vim.o.ei
 	vim.o.ei = "all" -- ignore all events
 	M.bo(buffer_id, { buftype = "nofile", bufhidden = "wipe", swapfile = false })
-	M.wo(window_id, { winhighlight = "Normal:Normal" })
+	M.wo(window_id, { winhighlight = "Normal:Normal", winblend = 100 })
 	vim.o.ei = ei
 	M.wins[tab].wins[M.wins[tab].active] = { win = window_id, buf = buffer_id }
 	vim.api.nvim_create_autocmd("BufWipeout", { buffer = buffer_id, callback = vim.schedule_wrap(M.check_wins) })
@@ -82,9 +82,8 @@ M.draw_character = function(row, col, character, hl_group, L)
 	end
 	-- logging.debug("Drawing character " .. character .. " at (" .. row .. ", " .. col .. ")")
 	local current_tab = vim.api.nvim_get_current_tabpage()
-	local window_id, buffer_id = M.get_win(current_tab, row, col)
+	local _, buffer_id = M.get_win(current_tab, row, col)
 
-	M.wo(window_id, { winblend = config.legacy_computing_symbols_support and 100 or 0 })
 	vim.api.nvim_buf_set_extmark(buffer_id, cursor_namespace, 0, 0, {
 		virt_text = { { character, hl_group } },
 		virt_text_win_col = 0,
@@ -97,7 +96,6 @@ M.clear = function()
 		for w = 1, M.wins[tab].active do
 			local win = M.wins[tab].wins[w]
 			if win and vim.api.nvim_win_is_valid(win.win) then
-				M.wo(win.win, { winblend = 100 })
 				vim.api.nvim_buf_clear_namespace(win.buf, cursor_namespace, 0, -1)
 				vim.api.nvim_win_set_config(win.win, { relative = "editor", row = 0, col = 0 })
 			end

--- a/lua/smear_cursor/draw.lua
+++ b/lua/smear_cursor/draw.lua
@@ -53,7 +53,7 @@ function M.get_win(tab, row, col)
 	local ei = vim.o.ei
 	vim.o.ei = "all" -- ignore all events
 	M.bo(buffer_id, { buftype = "nofile", bufhidden = "wipe", swapfile = false })
-	M.wo(window_id, { winhighlight = "Normal:Normal", winblend = 100 })
+	M.wo(window_id, { winhighlight = "NormalFloat:Normal", winblend = 100 })
 	vim.o.ei = ei
 	M.wins[tab].wins[M.wins[tab].active] = { win = window_id, buf = buffer_id }
 	vim.api.nvim_create_autocmd("BufWipeout", { buffer = buffer_id, callback = vim.schedule_wrap(M.check_wins) })


### PR DESCRIPTION
Use the `blend` property of hl groups to prevent needing to set `winblend` on every character draw.

Works with or without legacy symbols.

Builds on the wins PR. Actual changes: https://github.com/sphamba/smear-cursor.nvim/commit/335ae3f7cb542bb4973b077624d62a372c813511