### PR TITLE
fix: smear between windows on same screen line

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ return {
     -- Background color. Defaults to Normal GUI background color if not set.
     normal_bg = "#282828",
 
-    -- Smear cursor when switching buffers.
+    -- Smear cursor when switching buffers or windows.
     smear_between_buffers = true,
 
     -- Smear cursor when moving within line or to neighbor lines.

--- a/lua/smear_cursor/animation.lua
+++ b/lua/smear_cursor/animation.lua
@@ -10,6 +10,12 @@ local current_position = { 0, 0 }
 local trailing_position = { 0, 0 }
 local animating = false
 
+-- M.current_position = setmetatable({}, {
+-- 	__index = function(_, key)
+-- 		return current_position[key]
+-- 	end,
+-- })
+
 vim.defer_fn(function()
 	local cursor_row, cursor_col = screen.get_screen_cursor_position()
 	target_position = { cursor_row, cursor_col }
@@ -61,7 +67,6 @@ local function animate()
 end
 
 M.change_target_position = function(row, col, jump)
-	jump = jump or (not config.smear_between_neighbor_lines and math.abs(row - current_position[1]) <= 1)
 	if target_position[1] == row and target_position[2] == col then
 		return
 	end
@@ -85,5 +90,15 @@ M.change_target_position = function(row, col, jump)
 		animate()
 	end
 end
+
+setmetatable(M, {
+	__index = function(_, key)
+		if key == "current_position" then
+			return current_position
+		else
+			return nil
+		end
+	end,
+})
 
 return M

--- a/lua/smear_cursor/config.lua
+++ b/lua/smear_cursor/config.lua
@@ -2,7 +2,7 @@ local M = {}
 
 -- General configuration -------------------------------------------------------
 
--- Smear cursor when switching buffers
+-- Smear cursor when switching buffers or windows
 M.smear_between_buffers = true
 
 -- Smear cursor when moving within line or to neighbor lines

--- a/lua/smear_cursor/events.lua
+++ b/lua/smear_cursor/events.lua
@@ -7,7 +7,12 @@ local switching_buffer = false
 
 local function move_cursor()
 	local row, col = screen.get_screen_cursor_position()
-	local jump = not config.smear_between_buffers and switching_buffer
+	local jump = (not config.smear_between_buffers and switching_buffer)
+		or (
+			not config.smear_between_neighbor_lines
+			and not switching_buffer
+			and math.abs(row - animation.current_position[1]) <= 1
+		)
 	animation.change_target_position(row, col, jump)
 
 	switching_buffer = false

--- a/lua/smear_cursor/events.lua
+++ b/lua/smear_cursor/events.lua
@@ -38,7 +38,7 @@ M.listen = function()
 			autocmd CursorMoved,CursorMovedI * lua require("smear_cursor.color").update_color_at_cursor()
 			autocmd CursorMoved * lua require("smear_cursor.events").move_cursor()
 			autocmd CursorMovedI,WinScrolled * lua require("smear_cursor.events").jump_cursor()
-			autocmd BufLeave * lua require("smear_cursor.events").flag_switching_buffer()
+			autocmd BufLeave,WinLeave * lua require("smear_cursor.events").flag_switching_buffer()
 			autocmd ColorScheme * lua require("smear_cursor.color").clear_cache()
 		augroup END
 	]],


### PR DESCRIPTION
Smear between two windows to the same screen line even if `smear_between_neighbor_lines = true`

## Related GitHub issues and pull requests

- fix #31
