### PR TITLE
feat: add list of filetypes where smear is disabled

### DIFF
--- a/lua/smear_cursor/config.lua
+++ b/lua/smear_cursor/config.lua
@@ -25,6 +25,9 @@ M.hide_target_hack = true
 -- Number of windows that stay open for rendering.
 M.max_kept_windows = 50
 
+-- List of filetypes where the plugin is disabled.
+M.filetypes_disabled = {}
+
 M.time_interval = 17 -- milliseconds
 
 -- Smear configuration ---------------------------------------------------------

--- a/lua/smear_cursor/events.lua
+++ b/lua/smear_cursor/events.lua
@@ -49,6 +49,18 @@ M.listen = function()
 	]],
 		{}
 	)
+
+	if #config.filetypes_disabled > 0 then
+		vim.api.nvim_exec2(
+			[[
+		augroup SmearCursorIgnore
+			autocmd!
+			autocmd BufEnter * lua require("smear_cursor").enabled = not vim.tbl_contains(require("smear_cursor").filetypes_disabled, vim.bo.filetype)
+		augroup END
+	]],
+			{}
+		)
+	end
 end
 
 M.unlisten = function()


### PR DESCRIPTION
Add list of filetypes where smear is disabled

## Changes

- add config option `filetypes_disabled = {}`


## Related GitHub issues and pull requests

- fix #53 
