### PR TITLE
feat:scroll buffer space

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ return {
     -- Smear cursor when moving within line or to neighbor lines.
     smear_between_neighbor_lines = true,
 
+    -- Draw the smear in buffer space instead of screen space when scrolling
+    scroll_buffer_space = true,
+
     -- Set to `true` if your font supports legacy computing symbols (block unicode symbols).
     -- Smears will blend better on all backgrounds.
     legacy_computing_symbols_support = false,

--- a/lua/smear_cursor/animation.lua
+++ b/lua/smear_cursor/animation.lua
@@ -212,6 +212,7 @@ local function scroll_buffer_space()
 		-- Jump to show smear in buffer space instead of screen space
 		local shift = screen.get_screen_distance(previous_top_row, current_top_row)
 		set_corners(current_corners, current_corners[1][1] - shift, current_corners[1][2])
+		target_position[1] = target_position[1] - shift
 	end
 	previous_buffer_id = current_buffer_id
 	previous_top_row = current_top_row

--- a/lua/smear_cursor/animation.lua
+++ b/lua/smear_cursor/animation.lua
@@ -220,12 +220,26 @@ local function set_stiffnesses(head_stiffness, trailing_stiffness)
 	end
 end
 
+local function clamp_to_buffer(position)
+	local window_origin = vim.api.nvim_win_get_position(current_window_id)
+	local window_row = window_origin[1] + 1
+	-- local window_col = window_origin[2] + 1
+	local window_height = vim.api.nvim_win_get_height(current_window_id)
+	-- local window_width = vim.api.nvim_win_get_width(current_window_id)
+
+	position[1] = math.max(window_row, math.min(window_row + window_height - 1, position[1]))
+end
+
 local function scroll_buffer_space()
 	if current_top_row ~= previous_top_row then
 		-- Shift to show smear in buffer space instead of screen space
 		local shift = screen.get_screen_distance(previous_top_row, current_top_row)
-		set_corners(current_corners, current_corners[1][1] - shift, current_corners[1][2])
+		local shifted_position = { current_corners[1][1] - shift, current_corners[1][2] }
+		clamp_to_buffer(shifted_position)
+		set_corners(current_corners, shifted_position[1], shifted_position[2])
+
 		target_position[1] = target_position[1] - shift
+		clamp_to_buffer(target_position)
 	end
 end
 

--- a/lua/smear_cursor/config.lua
+++ b/lua/smear_cursor/config.lua
@@ -11,6 +11,9 @@ M.smear_between_buffers = true
 -- Smear cursor when moving within line or to neighbor lines
 M.smear_between_neighbor_lines = true
 
+-- Draw the smear in buffer space instead of screen space when scrolling
+M.scroll_buffer_space = true
+
 -- Set to `true` if your font supports legacy computing symbols (block unicode symbols).
 -- Smears will blend better on all backgrounds.
 M.legacy_computing_symbols_support = false

--- a/lua/smear_cursor/draw.lua
+++ b/lua/smear_cursor/draw.lua
@@ -102,6 +102,8 @@ end
 
 M.draw_character = function(row, col, character, hl_group)
 	-- logging.debug("Drawing character " .. character .. " at (" .. row .. ", " .. col .. ")")
+	if row < 1 or row > vim.o.lines or col < 1 or col > vim.o.columns then return end
+
 	local current_tab = vim.api.nvim_get_current_tabpage()
 	local _, buffer_id = get_window(current_tab, row, col)
 

--- a/lua/smear_cursor/events.lua
+++ b/lua/smear_cursor/events.lua
@@ -3,19 +3,9 @@ local config = require("smear_cursor.config")
 local screen = require("smear_cursor.screen")
 local M = {}
 
-local switching_buffer = false
-
 local function move_cursor()
 	local row, col = screen.get_screen_cursor_position()
-	local jump = (not config.smear_between_buffers and switching_buffer)
-		or (
-			not config.smear_between_neighbor_lines
-			and not switching_buffer
-			and math.abs(row - animation.target_position[1]) <= 1
-		)
-	animation.change_target_position(row, col, jump)
-
-	switching_buffer = false
+	animation.change_target_position(row, col)
 end
 
 M.move_cursor = function()
@@ -24,15 +14,11 @@ end
 
 local function jump_cursor()
 	local row, col = screen.get_screen_cursor_position()
-	animation.change_target_position(row, col, true)
+	animation.jump(row, col)
 end
 
 M.jump_cursor = function()
 	vim.defer_fn(jump_cursor, 0) -- for screen.get_screen_cursor_position()
-end
-
-M.flag_switching_buffer = function()
-	switching_buffer = true
 end
 
 M.listen = function()
@@ -43,7 +29,6 @@ M.listen = function()
 			autocmd CursorMoved,CursorMovedI * lua require("smear_cursor.color").update_color_at_cursor()
 			autocmd CursorMoved,WinScrolled * lua require("smear_cursor.events").move_cursor()
 			autocmd CursorMovedI,CursorHold * lua require("smear_cursor.events").jump_cursor()
-			autocmd BufLeave,WinLeave * lua require("smear_cursor.events").flag_switching_buffer()
 			autocmd ColorScheme * lua require("smear_cursor.color").clear_cache()
 		augroup END
 	]],

--- a/lua/smear_cursor/events.lua
+++ b/lua/smear_cursor/events.lua
@@ -41,8 +41,8 @@ M.listen = function()
 		augroup SmearCursor
 			autocmd!
 			autocmd CursorMoved,CursorMovedI * lua require("smear_cursor.color").update_color_at_cursor()
-			autocmd CursorMoved * lua require("smear_cursor.events").move_cursor()
-			autocmd CursorMovedI,WinScrolled * lua require("smear_cursor.events").jump_cursor()
+			autocmd CursorMoved,WinScrolled * lua require("smear_cursor.events").move_cursor()
+			autocmd CursorMovedI,CursorHold * lua require("smear_cursor.events").jump_cursor()
 			autocmd BufLeave,WinLeave * lua require("smear_cursor.events").flag_switching_buffer()
 			autocmd ColorScheme * lua require("smear_cursor.color").clear_cache()
 		augroup END

--- a/lua/smear_cursor/screen.lua
+++ b/lua/smear_cursor/screen.lua
@@ -16,4 +16,28 @@ M.get_screen_cursor_position = function()
 	return row, col
 end
 
+M.get_screen_distance = function(row_start, row_end)
+	local reversed = false
+
+	if row_start > row_end then
+		row_start, row_end = row_end, row_start
+		reversed = true
+	end
+
+	local text_height
+	local success = pcall(function()
+		text_height = vim.api.nvim_win_text_height(0, {
+			start_row = row_start - 1,
+			end_row = row_end - 1,
+		})
+	end)
+
+	if not success then -- line is not visible
+		text_height = { all = 1 }
+	end
+
+	local distance = text_height.all - 1
+	return reversed and -distance or distance
+end
+
 return M


### PR DESCRIPTION
When scrolling in a buffer, show the smear from the previous buffer position instead of the previous screen position.

## Changes

- add config parameter `scroll_buffer_space` (`true` by default).


## Related GitHub issues and pull requests

- fix #40 and #51
