### PR TITLE
feat:cterm colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ return {
 }
 ```
 
-Refer to [`lua/smear_cursor/config.lua`](https://github.com/sphamba/smear-cursor.nvim/blob/main/lua/smear_cursor/config.lua) for the full list of configuration options that can be set with `opts`.
+Refer to [`lua/smear_cursor/config.lua`](https://github.com/sphamba/smear-cursor.nvim/blob/main/lua/smear_cursor/config.lua) and [`lua/smear_cursor/color.lua`](https://github.com/sphamba/smear-cursor.nvim/blob/main/lua/smear_cursor/color.lua) for the full list of configuration options that can be set with `opts`.
 
 > [!TIP]
 > Some terminals override the cursor color set by Neovim. If that is the case, manually put the actual cursor color in your config, as shown above, to get a matching smear color.

--- a/README.md
+++ b/README.md
@@ -59,13 +59,6 @@ return {
   "sphamba/smear-cursor.nvim",
 
   opts = {
-    -- Smear cursor color. Defaults to Cursor GUI color if not set.
-    -- Set to "none" to match the text color at the target cursor position.
-    cursor_color = "#d3cdc3",
-
-    -- Background color. Defaults to Normal GUI background color if not set.
-    normal_bg = "#282828",
-
     -- Smear cursor when switching buffers or windows.
     smear_between_buffers = true,
 
@@ -85,10 +78,20 @@ return {
 Refer to [`lua/smear_cursor/config.lua`](https://github.com/sphamba/smear-cursor.nvim/blob/main/lua/smear_cursor/config.lua) and [`lua/smear_cursor/color.lua`](https://github.com/sphamba/smear-cursor.nvim/blob/main/lua/smear_cursor/color.lua) for the full list of configuration options that can be set with `opts`.
 
 > [!TIP]
-> Some terminals override the cursor color set by Neovim. If that is the case, manually put the actual cursor color in your config, as shown above, to get a matching smear color.
+> Some terminals override the cursor color set by Neovim. If that is the case, manually put the actual cursor color in your config to get a matching smear color:
+> ```lua
+>   opts = {
+>     -- Smear cursor color. Defaults to Cursor GUI color if not set.
+>     -- Set to "none" to match the text color at the target cursor position.
+>     cursor_color = "#d3cdc3",
+>   }
+> ```
 
 
-### Faster smear
+### Examples
+
+<details>
+<summary>🔥 Faster smear</summary>
 
 As an example of further configuration, you can tune the smear dynamics to be snappier:
 ```lua
@@ -100,7 +103,6 @@ As an example of further configuration, you can tune the smear dynamics to be sn
   },
 ```
 
-
 > [!WARNING]
 > **🔥 FIRE HAZARD 🔥** Feel free to experiment with all the configuration options, but be aware that some combinations may cause your cursor to flicker or even **catch fire**. That can happen with the following settings:
 > ```lua
@@ -108,13 +110,15 @@ As an example of further configuration, you can tune the smear dynamics to be sn
 >     cursor_color = "#ff8800",
 >     stiffness = 0.3,
 >     trailing_stiffness = 0.1,
->     trailing_exponent = 3,
+>     trailing_exponent = 5,
 >     gamma = 1,
->     volume_reduction_exponent = -0.1,
 >   }
 > ```
 
-### Transparent background
+</details>
+
+<details>
+<summary>🌌 Transparent background</summary>
 
 Drawing the smear over a transparent background works better when using a font that supports legacy computing symbols, therefore setting the following option:
 ```lua
@@ -129,6 +133,8 @@ If your font does not support legacy computing symbols, there will be a shadow u
     transparent_bg_fallback_color = "#303030",
   },
 ```
+
+</details>
 
 
 ### Using `init.vim`

--- a/README.md
+++ b/README.md
@@ -136,6 +136,19 @@ If your font does not support legacy computing symbols, there will be a shadow u
 
 </details>
 
+<details>
+<summary>🔲 No GUI colors</summary>
+
+If you are not using `termguicolors`, you need to manually set a color gradient for the smear (it can be a single color):
+```lua
+  opts = {
+    cterm_cursor_colors = { 240, 245, 250, 255 },
+    cterm_bg = 235,
+  }
+```
+
+</details>
+
 
 ### Using `init.vim`
 

--- a/lua/smear_cursor/color.lua
+++ b/lua/smear_cursor/color.lua
@@ -1,3 +1,23 @@
+-- The following options can be set using the `setup` function.
+-- Refer to the README for more information.
+
+-- Color configuration ---------------------------------------------------------
+
+-- Smear cursor color. Defaults to Cursor GUI color if not set.
+-- Set to "none" to match the text color at the target cursor position.
+local cursor_color = nil
+
+-- Cterm color gradient, from bg color (excluded) to cursor color (included)
+-- When set, `cursor_color` is ignored
+local cterm_cursor_colors = nil
+
+-- Background color. Defaults to Normal GUI background color if not set.
+local normal_bg = nil
+
+local transparent_bg_fallback_color = "#303030"
+
+--------------------------------------------------------------------------------
+
 local config = require("smear_cursor.config")
 local round = require("smear_cursor.math").round
 local M = {}
@@ -9,10 +29,7 @@ local function get_hl_color(group, attr)
 	return nil
 end
 
-local cursor_color = nil
 local color_at_cursor = nil
-local normal_bg = nil
-local transparent_bg_fallback_color = "#303030"
 local cache = {} ---@type table<string, boolean>
 
 local function hex_to_rgb(hex)
@@ -118,6 +135,8 @@ setmetatable(M, {
 	__index = function(_, key)
 		if key == "cursor_color" then
 			return cursor_color
+		elseif key == "cterm_cursor_colors" then
+			return cterm_cursor_colors
 		elseif key == "normal_bg" then
 			return normal_bg
 		elseif key == "transparent_bg_fallback_color" then
@@ -130,6 +149,10 @@ setmetatable(M, {
 	__newindex = function(table, key, value)
 		if key == "cursor_color" then
 			cursor_color = value
+			M.clear_cache()
+		elseif key == "cterm_cursor_colors" then
+			cterm_cursor_colors = value
+			config.color_levels = #value
 			M.clear_cache()
 		elseif key == "normal_bg" then
 			normal_bg = value

--- a/lua/smear_cursor/config.lua
+++ b/lua/smear_cursor/config.lua
@@ -28,6 +28,9 @@ M.hide_target_hack = true
 -- Number of windows that stay open for rendering.
 M.max_kept_windows = 50
 
+-- Adjust to have the smear appear above or below other floating windows
+M.windows_zindex = 300
+
 -- List of filetypes where the plugin is disabled.
 M.filetypes_disabled = {}
 
@@ -58,7 +61,7 @@ M.distance_stop_animating = 0.1
 M.max_slope_horizontal = 0.5
 M.min_slope_vertical = 2
 
-M.color_levels = 16 -- Minimum 1
+M.color_levels = 16 -- Minimum 1, don't set manually if using cterm_cursor_colors
 M.gamma = 2.2 -- For color blending
 M.max_shade_no_matrix = 0.75 -- 0: more overhangs, 1: more matrices
 M.matrix_pixel_threshold = 0.7 -- 0: all pixels, 1: no pixel

--- a/lua/smear_cursor/draw.lua
+++ b/lua/smear_cursor/draw.lua
@@ -86,7 +86,7 @@ local function get_window(tab, row, col)
 		style = "minimal",
 		focusable = false,
 		noautocmd = true,
-		zindex = 300,
+		zindex = config.windows_zindex,
 	})
 
 	set_buffer_options(

--- a/lua/smear_cursor/events.lua
+++ b/lua/smear_cursor/events.lua
@@ -28,7 +28,7 @@ M.listen = function()
 			autocmd!
 			autocmd CursorMoved,CursorMovedI * lua require("smear_cursor.color").update_color_at_cursor()
 			autocmd CursorMoved,WinScrolled * lua require("smear_cursor.events").move_cursor()
-			autocmd CursorMovedI,CursorHold * lua require("smear_cursor.events").jump_cursor()
+			autocmd CursorMovedI * lua require("smear_cursor.events").jump_cursor()
 			autocmd ColorScheme * lua require("smear_cursor.color").clear_cache()
 		augroup END
 	]],

--- a/lua/smear_cursor/init.lua
+++ b/lua/smear_cursor/init.lua
@@ -14,7 +14,7 @@ local metatable = {
 	__index = function(table, key)
 		if key == "enabled" then return enabled end
 
-		if key == "cursor_color" or key == "normal_bg" then return color[key] end
+		if vim.tbl_contains(color.config_variables, key) then return color[key] end
 
 		if config[key] ~= nil then return config[key] end
 
@@ -29,7 +29,7 @@ local metatable = {
 			else
 				events.unlisten()
 			end
-		elseif key == "cursor_color" or key == "normal_bg" then
+		elseif vim.tbl_contains(color.config_variables, key) then
 			color[key] = value
 		elseif key == "legacy_computing_symbols_support" then
 			config.legacy_computing_symbols_support = value


### PR DESCRIPTION
Add default and configurable cterm color gradient. Example:
```lua
opts = {
  cterm_cursor_colors = { 240, 245, 250, 255 },
  cterm_bg = 235,
}
```

## Changes

- add `cterm_cursor_colors` and `cterm_bg` configuration variables


## Related GitHub issues and pull requests

- fix #50
