### PR TITLE
fix: error when cursor color is none

### DIFF
--- a/lua/smear_cursor/color.lua
+++ b/lua/smear_cursor/color.lua
@@ -126,7 +126,9 @@ function M.get_hl_group(opts)
 	if cache[hl_group] then return hl_group end
 
 	-- Retrieve the cursor color and the normal background color if not set by the user
-	_cursor_color = _cursor_color or get_hl_color("Cursor", "bg") or get_hl_color("Normal", "fg") or "#d0d0d0"
+	if _cursor_color == "none" then
+		_cursor_color = get_hl_color("Cursor", "bg") or get_hl_color("Normal", "fg") or "#d0d0d0"
+	end
 	local _normal_bg = C.normal_bg or get_hl_color("Normal", "bg") or "none"
 	---@type integer?
 	local _cterm_cursor_color = C.cterm_cursor_colors and C.cterm_cursor_colors[#C.cterm_cursor_colors] or nil


### PR DESCRIPTION
The value of `_cursor_color` was being checked against if it was falsy before falling through to another option. As far as I can tell, it should instead be compared to the string literal "none".

## Related GitHub issues and pull requests

- fix #68 
