### PR TITLE
Feat: smear to command line

### DIFF
--- a/lua/smear_cursor/animation.lua
+++ b/lua/smear_cursor/animation.lua
@@ -173,6 +173,7 @@ local function animate()
 
 	if max_distance <= config.distance_stop_animating then
 		set_corners(current_corners, target_position[1], target_position[2])
+		vim.cmd.redraw()
 		stop_animation()
 		return
 	end

--- a/lua/smear_cursor/draw.lua
+++ b/lua/smear_cursor/draw.lua
@@ -102,7 +102,7 @@ end
 
 M.draw_character = function(row, col, character, hl_group)
 	-- logging.debug("Drawing character " .. character .. " at (" .. row .. ", " .. col .. ")")
-	if row < 1 or row > vim.o.lines or col < 1 or col > vim.o.columns then return end
+	if row < 1 or row > vim.o.lines - vim.opt.cmdheight._value or col < 1 or col > vim.o.columns then return end
 
 	local current_tab = vim.api.nvim_get_current_tabpage()
 	local _, buffer_id = get_window(current_tab, row, col)

--- a/lua/smear_cursor/events.lua
+++ b/lua/smear_cursor/events.lua
@@ -27,13 +27,13 @@ end
 
 M.enter_cmd = function()
 	local row = get_cmd_row()
-	local col = vim.fn.getcmdpos()
+	local col = vim.fn.getcmdpos() + 1
 	animation.change_target_position(row, col)
 end
 
 M.change_cmd = function()
 	local row = get_cmd_row()
-	local col = vim.fn.getcmdpos()
+	local col = vim.fn.getcmdpos() + 1
 	animation.jump(row, col)
 end
 

--- a/lua/smear_cursor/events.lua
+++ b/lua/smear_cursor/events.lua
@@ -21,14 +21,32 @@ M.jump_cursor = function()
 	vim.defer_fn(jump_cursor, 0) -- for screen.get_screen_cursor_position()
 end
 
+local function get_cmd_row()
+	return vim.o.lines - vim.opt.cmdheight._value + 1
+end
+
+M.enter_cmd = function()
+	local row = get_cmd_row()
+	local col = vim.fn.getcmdpos()
+	animation.change_target_position(row, col)
+end
+
+M.change_cmd = function()
+	local row = get_cmd_row()
+	local col = vim.fn.getcmdpos()
+	animation.jump(row, col)
+end
+
 M.listen = function()
 	vim.api.nvim_exec2(
 		[[
 		augroup SmearCursor
 			autocmd!
 			autocmd CursorMoved,CursorMovedI * lua require("smear_cursor.color").update_color_at_cursor()
-			autocmd CursorMoved,WinScrolled * lua require("smear_cursor.events").move_cursor()
+			autocmd CmdlineLeave,CmdwinEnter,CursorMoved,WinScrolled * lua require("smear_cursor.events").move_cursor()
 			autocmd CursorMovedI * lua require("smear_cursor.events").jump_cursor()
+			autocmd CmdlineEnter,CmdwinLeave * lua require("smear_cursor.events").enter_cmd()
+			autocmd CmdlineChanged * lua require("smear_cursor.events").change_cmd()
 			autocmd ColorScheme * lua require("smear_cursor.color").clear_cache()
 		augroup END
 	]],


### PR DESCRIPTION
Use `vim.uv` timer intervals instead of timeouts for animation, which doesn't freeze when opening the command line.

## Changes

- replace `vim.defer_fn(animate, config.time_interval)` with `timer:start(0, config.time_interval, vim.schedule_wrap(animate))`
- remove drawing of previous smear on fast cursor move to avoid random jumps
- add smear to command line and command window


## Related GitHub issues and pull requests

- fix #9
- fix one case of #15 
