### PR TITLE
fix: jump to cmd line when hitting some keybindings

### DIFF
--- a/lua/smear_cursor/animation.lua
+++ b/lua/smear_cursor/animation.lua
@@ -10,7 +10,6 @@ local target_position = { 0, 0 }
 local current_corners = {}
 local target_corners = {}
 local stiffnesses = { 0, 0, 0, 0 }
-local previous_ending_drawn = false -- only draw previous smear once
 
 local previous_window_id = -1
 local current_window_id = -1
@@ -294,18 +293,6 @@ M.change_target_position = function(row, col)
 
 	if target_position[1] == row and target_position[2] == col then return end
 	draw.clear()
-
-	-- Draw end of previous smear
-	if animating then
-		if not previous_ending_drawn then
-			set_stiffnesses(1, 0)
-			update()
-			draw.draw_quad(shrink_volume(current_corners), target_position)
-			vim.cmd.redraw()
-			previous_ending_drawn = true
-		end
-		set_corners(current_corners, target_position[1], target_position[2])
-	end
 
 	target_position = { row, col }
 	set_corners(target_corners, row, col)

--- a/lua/smear_cursor/animation.lua
+++ b/lua/smear_cursor/animation.lua
@@ -150,7 +150,7 @@ local function shrink_volume(corners)
 end
 
 local function stop_animation()
-	if not animating then return end
+	if timer == nil then return end
 	timer:stop()
 	timer:close()
 	timer = nil
@@ -158,6 +158,7 @@ local function stop_animation()
 end
 
 local function animate()
+	animating = true
 	update()
 
 	local max_distance = 0
@@ -212,10 +213,9 @@ local function animate()
 end
 
 local function start_anination()
-	if animating then return end
+	if timer ~= nil then return end
 	timer = vim.uv.new_timer()
-	animating = true
-	timer:start(0, config.time_interval, vim.schedule_wrap(animate))
+	timer:start(config.delay_animation_start, config.time_interval, vim.schedule_wrap(animate))
 end
 
 local function set_stiffnesses(head_stiffness, trailing_stiffness)
@@ -310,6 +310,7 @@ M.change_target_position = function(row, col)
 	target_position = { row, col }
 	set_corners(target_corners, row, col)
 	set_stiffnesses(config.stiffness, config.trailing_stiffness)
+	-- print(row, col, current_corners[1][1], current_corners[1][2])
 
 	start_anination()
 end

--- a/lua/smear_cursor/config.lua
+++ b/lua/smear_cursor/config.lua
@@ -34,7 +34,14 @@ M.windows_zindex = 300
 -- List of filetypes where the plugin is disabled.
 M.filetypes_disabled = {}
 
+-- Sets animation framerate
 M.time_interval = 17 -- milliseconds
+
+-- After changing target position, wait before triggering animation.
+-- Useful if the target changes and rapidly comes back to its original position.
+-- E.g. when hitting a keybinding that triggers CmdlineEnter.
+-- Increase if the cursor makes weird jumps when hitting keys.
+M.delay_animation_start = 5 -- milliseconds
 
 -- Smear configuration ---------------------------------------------------------
 

--- a/lua/smear_cursor/events.lua
+++ b/lua/smear_cursor/events.lua
@@ -25,16 +25,10 @@ local function get_cmd_row()
 	return vim.o.lines - vim.opt.cmdheight._value + 1
 end
 
-M.enter_cmd = function()
+M.cmd_update = function()
 	local row = get_cmd_row()
 	local col = vim.fn.getcmdpos() + 1
 	animation.change_target_position(row, col)
-end
-
-M.change_cmd = function()
-	local row = get_cmd_row()
-	local col = vim.fn.getcmdpos() + 1
-	animation.jump(row, col)
 end
 
 M.listen = function()
@@ -45,8 +39,7 @@ M.listen = function()
 			autocmd CursorMoved,CursorMovedI * lua require("smear_cursor.color").update_color_at_cursor()
 			autocmd CmdlineLeave,CmdwinEnter,CursorMoved,WinScrolled * lua require("smear_cursor.events").move_cursor()
 			autocmd CursorMovedI * lua require("smear_cursor.events").jump_cursor()
-			autocmd CmdlineEnter,CmdwinLeave * lua require("smear_cursor.events").enter_cmd()
-			autocmd CmdlineChanged * lua require("smear_cursor.events").change_cmd()
+			autocmd CmdlineEnter,CmdlineChanged,CmdwinLeave * lua require("smear_cursor.events").cmd_update()
 			autocmd ColorScheme * lua require("smear_cursor.color").clear_cache()
 		augroup END
 	]],


### PR DESCRIPTION
Add a delay between detected events and starting of the animation, in case the target changes rapidly.
Happens when hitting keybindings that rapidly trigger `CmdlineEnter`, `CmdlineChanged`, and `CmdlineLeave` events.

## Changes

- add delay before starting animation
- add `delay_animation_start` configuration parameter, default to `5` milliseconds


## Related GitHub issues and pull requests

- fix #73
- fix #74
