### PR TITLE
feat: add parameter to enable/disable smear to cmd line

### DIFF
--- a/lua/smear_cursor/config.lua
+++ b/lua/smear_cursor/config.lua
@@ -11,6 +11,9 @@ M.smear_between_buffers = true
 -- Smear cursor when moving within line or to neighbor lines
 M.smear_between_neighbor_lines = true
 
+-- Smear cursor when entering or leaving command line mode
+M.smear_to_cmd = true
+
 -- Draw the smear in buffer space instead of screen space when scrolling
 M.scroll_buffer_space = true
 

--- a/lua/smear_cursor/events.lua
+++ b/lua/smear_cursor/events.lua
@@ -26,6 +26,7 @@ local function get_cmd_row()
 end
 
 M.cmd_update = function()
+	if not config.smear_to_cmd then return end
 	local row = get_cmd_row()
 	local col = vim.fn.getcmdpos() + 1
 	animation.change_target_position(row, col)


### PR DESCRIPTION
Add `smear_to_cmd` configuration parameter, controlling whether `CmdlineEnter,CmdlineChanged,CmdwinLeave` events are listened. `true` by default.