### PR TITLE
chore: simplify autocmd for command line events

### DIFF
--- a/lua/smear_cursor/config.lua
+++ b/lua/smear_cursor/config.lua
@@ -44,7 +44,7 @@ M.time_interval = 17 -- milliseconds
 -- Useful if the target changes and rapidly comes back to its original position.
 -- E.g. when hitting a keybinding that triggers CmdlineEnter.
 -- Increase if the cursor makes weird jumps when hitting keys.
-M.delay_animation_start = 5 -- milliseconds
+M.delay_animation_start = 0 -- milliseconds
 
 -- Smear configuration ---------------------------------------------------------
 

--- a/lua/smear_cursor/events.lua
+++ b/lua/smear_cursor/events.lua
@@ -43,9 +43,8 @@ M.listen = function()
 		augroup SmearCursor
 			autocmd!
 			autocmd CursorMoved,CursorMovedI * lua require("smear_cursor.color").update_color_at_cursor()
-			autocmd CmdlineLeave,CmdwinEnter,CursorMoved,WinScrolled * lua require("smear_cursor.events").move_cursor()
+			autocmd CursorMoved,ModeChanged,WinScrolled * lua require("smear_cursor.events").move_cursor()
 			autocmd CursorMovedI * lua require("smear_cursor.events").jump_cursor()
-			autocmd CmdlineEnter,CmdlineChanged,CmdwinLeave * lua require("smear_cursor.events").move_cursor()
 			autocmd ColorScheme * lua require("smear_cursor.color").clear_cache()
 		augroup END
 	]],


### PR DESCRIPTION
Use (deferred) `vim.api.nvim_get_mode()` to choose how to compute the cursor position, instead of relying on the triggering neovim event.

## Changes

- change `delay_animation_start` to 0 milliseconds by default. Perhaps not needed anymore.


## Related GitHub issues and pull requests

- fix #79 
