### PR TITLE
feat: add minimum smear activation distances

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ return {
     smear_between_buffers = true,
 
     -- Smear cursor when moving within line or to neighbor lines.
+    -- Use `min_horizontal_distance_smear` and `min_vertical_distance_smear` for finer control
     smear_between_neighbor_lines = true,
 
     -- Draw the smear in buffer space instead of screen space when scrolling

--- a/lua/smear_cursor/animation.lua
+++ b/lua/smear_cursor/animation.lua
@@ -280,7 +280,16 @@ M.change_target_position = function(row, col)
 
 	if current_window_id == previous_window_id and current_buffer_id == previous_buffer_id then
 		if config.scroll_buffer_space then scroll_buffer_space() end
-		if not config.smear_between_neighbor_lines and not animating and math.abs(row - target_position[1]) <= 1 then
+		if
+			not animating
+			and (
+				(not config.smear_between_neighbor_lines and math.abs(row - target_position[1]) <= 1)
+				or (
+					math.abs(row - target_position[1]) < config.min_vertical_distance_smear
+					and math.abs(col - target_position[2]) < config.min_horizontal_distance_smear
+				)
+			)
+		then
 			M.jump(row, col)
 			return
 		end

--- a/lua/smear_cursor/config.lua
+++ b/lua/smear_cursor/config.lua
@@ -9,7 +9,12 @@ local M = {}
 M.smear_between_buffers = true
 
 -- Smear cursor when moving within line or to neighbor lines
+-- Use `min_horizontal_distance_smear` and `min_vertical_distance_smear` for finer control
 M.smear_between_neighbor_lines = true
+
+-- Only smear cursor when moving at least these distances
+M.min_horizontal_distance_smear = 0
+M.min_vertical_distance_smear = 0
 
 -- Smear cursor when entering or leaving command line mode
 M.smear_to_cmd = true


### PR DESCRIPTION
Add minimum smear activation distances (horizontal and vertical) with parameters `min_horizontal_distance_smear` and `min_vertical_distance_smear` set to 0 by default.


## Related GitHub issues and pull requests

- fix #83 
