### PR TITLE
feat: smear insert mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ return {
     -- Set to `true` if your font supports legacy computing symbols (block unicode symbols).
     -- Smears will blend better on all backgrounds.
     legacy_computing_symbols_support = false,
+
+    -- Smear cursor in insert mode.
+    -- See also `vertical_bar_cursor_insert_mode` and `distance_stop_animating_vertical_bar`.
+    smear_insert_mode = true,
   },
 }
 ```

--- a/lua/smear_cursor/animation.lua
+++ b/lua/smear_cursor/animation.lua
@@ -21,7 +21,7 @@ local previous_line = -1
 local current_line = -1
 
 local function cursor_is_vertical_bar()
-	if vim.api.nvim_get_mode()["mode"] == "i" then
+	if vim.api.nvim_get_mode().mode == "i" then
 		return config.vertical_bar_cursor_insert_mode
 	else
 		return config.vertical_bar_cursor
@@ -62,7 +62,7 @@ end, 0)
 local function update()
 	local distance_head_to_target = math.huge
 	local index_head = 0
-	local max_length = vim.api.nvim_get_mode()["mode"] == "i" and config.max_length_insert_mode or config.max_length
+	local max_length = vim.api.nvim_get_mode().mode == "i" and config.max_length_insert_mode or config.max_length
 
 	-- Move toward targets
 	for i = 1, 4 do
@@ -243,7 +243,7 @@ local function set_stiffnesses()
 	local max_distance = 0
 	local head_stiffness, trailing_stiffness, trailing_exponent
 
-	if vim.api.nvim_get_mode()["mode"] == "i" then
+	if vim.api.nvim_get_mode().mode == "i" then
 		head_stiffness = config.stiffness_insert_mode
 		trailing_stiffness = config.trailing_stiffness_insert_mode
 		trailing_exponent = config.trailing_exponent_insert_mode
@@ -330,6 +330,7 @@ M.change_target_position = function(row, col)
 		end
 	end
 
+	if target_position[1] == row and target_position[2] == col and vim.api.nvim_get_mode().mode ~= "i" then return end
 	draw.clear()
 
 	target_position = { row, col }

--- a/lua/smear_cursor/animation.lua
+++ b/lua/smear_cursor/animation.lua
@@ -204,7 +204,7 @@ local function animate()
 
 	local vertical_bar = cursor_is_vertical_bar()
 
-	if config.hide_target_hack then
+	if config.hide_target_hack and not vertical_bar then
 		-- stylua: ignore
 		local target_reached = (
 			math.floor(drawn_corners[1][1]) == target_position[1] and

--- a/lua/smear_cursor/animation.lua
+++ b/lua/smear_cursor/animation.lua
@@ -233,7 +233,7 @@ end
 local function start_anination()
 	if timer ~= nil then return end
 	timer = vim.uv.new_timer()
-	timer:start(config.delay_animation_start, config.time_interval, vim.schedule_wrap(animate))
+	timer:start(0, config.time_interval, vim.schedule_wrap(animate))
 end
 
 local function set_stiffnesses()

--- a/lua/smear_cursor/animation.lua
+++ b/lua/smear_cursor/animation.lua
@@ -171,16 +171,24 @@ local function animate()
 	update()
 
 	local max_distance = 0
+	local left_bound = vim.o.columns
+	local right_bound = 0
 	for i = 1, 4 do
 		local distance = math.sqrt(
 			(current_corners[i][1] - target_corners[i][1]) ^ 2 + (current_corners[i][2] - target_corners[i][2]) ^ 2
 		)
 		max_distance = math.max(max_distance, distance)
+		left_bound = math.min(left_bound, current_corners[i][2])
+		right_bound = math.max(right_bound, current_corners[i][2])
 	end
+	local thickness = right_bound - left_bound
 
 	draw.clear()
 
-	if max_distance <= config.distance_stop_animating then
+	if
+		max_distance <= config.distance_stop_animating
+		or (thickness <= 1.5 / 8 and max_distance <= config.distance_stop_animating_vertical_bar)
+	then
 		set_corners(current_corners, target_position[1], target_position[2])
 		vim.cmd.redraw()
 		stop_animation()

--- a/lua/smear_cursor/config.lua
+++ b/lua/smear_cursor/config.lua
@@ -78,9 +78,10 @@ M.slowdown_exponent = 0
 M.distance_stop_animating = 0.1
 
 -- Set of parameters for insert mode
-M.stiffness_insert_mode = 0.5
-M.trailing_stiffness_insert_mode = 0.5
+M.stiffness_insert_mode = 0.4
+M.trailing_stiffness_insert_mode = 0.4
 M.trailing_exponent_insert_mode = 1
+M.distance_stop_animating_vertical_bar = 0.875 -- Can be decreased (e.g. to 0.1) if using legacy computing symbols
 
 -- When to switch between rasterization methods
 M.max_slope_horizontal = 0.5

--- a/lua/smear_cursor/config.lua
+++ b/lua/smear_cursor/config.lua
@@ -29,7 +29,8 @@ M.legacy_computing_symbols_support = false
 -- Set to `true` if your cursor is a vertical bar in normal mode.
 M.vertical_bar_cursor = false
 
--- Smear cursor in insert mode
+-- Smear cursor in insert mode.
+-- See also `vertical_bar_cursor_insert_mode` and `distance_stop_animating_vertical_bar`.
 M.smear_insert_mode = true
 
 -- Set to `true` if your cursor is a vertical bar in insert mode.

--- a/lua/smear_cursor/config.lua
+++ b/lua/smear_cursor/config.lua
@@ -27,8 +27,13 @@ M.scroll_buffer_space = true
 M.legacy_computing_symbols_support = false
 
 -- Set to `true` if your cursor is a vertical bar in normal mode.
--- Use with `matrix_pixel_threshold = 0.3`
 M.vertical_bar_cursor = false
+
+-- Smear cursor in insert mode
+M.smear_insert_mode = true
+
+-- Set to `true` if your cursor is a vertical bar in insert mode.
+M.vertical_bar_cursor_insert_mode = true
 
 -- Attempt to hide the real cursor by drawing a character below it.
 M.hide_target_hack = true
@@ -72,6 +77,11 @@ M.slowdown_exponent = 0
 -- Stop animating when the smear's tail is within this distance (in characters) from the target.
 M.distance_stop_animating = 0.1
 
+-- Set of parameters for insert mode
+M.stiffness_insert_mode = 0.6
+M.trailing_stiffness_insert_mode = 0.6
+M.trailing_exponent_insert_mode = 1
+
 -- When to switch between rasterization methods
 M.max_slope_horizontal = 0.5
 M.min_slope_vertical = 2
@@ -80,10 +90,12 @@ M.color_levels = 16 -- Minimum 1, don't set manually if using cterm_cursor_color
 M.gamma = 2.2 -- For color blending
 M.max_shade_no_matrix = 0.75 -- 0: more overhangs, 1: more matrices
 M.matrix_pixel_threshold = 0.7 -- 0: all pixels, 1: no pixel
+M.matrix_pixel_threshold_vertical_bar = 0.3 -- 0: all pixels, 1: no pixel
 M.matrix_pixel_min_factor = 0.5 -- 0: all pixels, 1: no pixel
 M.volume_reduction_exponent = 0.3 -- 0: no reduction, 1: full reduction
 M.minimum_volume_factor = 0.7 -- 0: no limit, 1: no reduction
 M.max_length = 25 -- Maximum smear length
+M.max_length_insert_mode = 1
 
 -- For debugging ---------------------------------------------------------------
 

--- a/lua/smear_cursor/config.lua
+++ b/lua/smear_cursor/config.lua
@@ -78,8 +78,8 @@ M.slowdown_exponent = 0
 M.distance_stop_animating = 0.1
 
 -- Set of parameters for insert mode
-M.stiffness_insert_mode = 0.6
-M.trailing_stiffness_insert_mode = 0.6
+M.stiffness_insert_mode = 0.5
+M.trailing_stiffness_insert_mode = 0.5
 M.trailing_exponent_insert_mode = 1
 
 -- When to switch between rasterization methods

--- a/lua/smear_cursor/config.lua
+++ b/lua/smear_cursor/config.lua
@@ -50,11 +50,11 @@ M.filetypes_disabled = {}
 -- Sets animation framerate
 M.time_interval = 17 -- milliseconds
 
--- After changing target position, wait before triggering animation.
+-- Amount of time the cursor has to stay still before triggering animation.
 -- Useful if the target changes and rapidly comes back to its original position.
 -- E.g. when hitting a keybinding that triggers CmdlineEnter.
 -- Increase if the cursor makes weird jumps when hitting keys.
-M.delay_animation_start = 0 -- milliseconds
+M.delay_event_to_smear = 1 -- milliseconds
 
 -- Smear configuration ---------------------------------------------------------
 

--- a/lua/smear_cursor/draw.lua
+++ b/lua/smear_cursor/draw.lua
@@ -151,9 +151,11 @@ local function draw_partial_block(row, col, character_list, character_index, hl_
 	M.draw_character(row, col, character, hl_group)
 end
 
-local function draw_matrix_character(row, col, matrix)
+local function draw_matrix_character(row, col, matrix, vertical_bar)
 	local max = math.max(matrix[1][1], matrix[1][2], matrix[2][1], matrix[2][2])
-	if max < config.matrix_pixel_threshold then return end
+	local matrix_pixel_threshold = vertical_bar and config.matrix_pixel_threshold_vertical_bar
+		or config.matrix_pixel_threshold
+	if max < matrix_pixel_threshold then return end
 	local threshold = max * config.matrix_pixel_min_factor
 	local bit_1 = (matrix[1][1] > threshold) and 1 or 0
 	local bit_2 = (matrix[1][2] > threshold) and 1 or 0
@@ -523,7 +525,7 @@ local function update_matrix_with_edge(edge_index, matrix_index, row, col, G, ma
 	update_matrix_with_edge_functions[edge_type](edge_index, matrix_index, row, col, G, matrix)
 end
 
-M.draw_quad = function(corners, target_position)
+M.draw_quad = function(corners, target_position, vertical_bar)
 	if target_position == nil then target_position = { 0, 0 } end
 
 	bulge_above = not bulge_above
@@ -537,7 +539,7 @@ M.draw_quad = function(corners, target_position)
 
 		for col = math.max(G.left, math.floor(left)), math.min(G.right, math.ceil(right)) do
 			-- Check if on target
-			if row == target_position[1] and col == target_position[2] then goto continue end
+			if not vertical_bar and row == target_position[1] and col == target_position[2] then goto continue end
 
 			local intersections = {}
 			for i = 1, 4 do
@@ -620,7 +622,7 @@ M.draw_quad = function(corners, target_position)
 				end
 			end
 
-			draw_matrix_character(row, col, matrix)
+			draw_matrix_character(row, col, matrix, vertical_bar)
 
 			::continue::
 		end

--- a/lua/smear_cursor/draw.lua
+++ b/lua/smear_cursor/draw.lua
@@ -9,6 +9,7 @@ local LEFT_BLOCKS       = { " ", "▏", "▎", "▍", "▌", "▋", "▊", "▉"
 local TOP_BLOCKS        = { " ", "▔", "🮂", "🮃", "▀", "🮄", "🮅", "🮆", "█" }
 local RIGHT_BLOCKS      = { "█", "🮋", "🮊", "🮉", "▐", "🮈", "🮇", "▕", " " }
 local MATRIX_CHARACTERS = { "▘", "▝", "▀", "▖", "▌", "▞", "▛", "▗", "▚", "▐", "▜", "▄", "▙", "▟", "█" }
+local VERTICAL_BARS     = { "▏", "🭰", "🭱", "🭲", "🭳", "🭳", "🭵", "▕" }
 -- stylua: ignore end
 
 -- Enums for drawing quad
@@ -245,6 +246,21 @@ local function draw_vertically_shifted_sub_block(row_top, row_bottom, col, shade
 	draw_partial_block(row, col, character_list, character_index, hl_group)
 end
 
+local function get_vertical_bar_properties(micro_shift, thickness, shade)
+	local character_index = math.floor(micro_shift)
+	if character_index < 0 or character_index >= 8 then return end
+
+	local character_thickness = 1 / 8
+	shade = math.min(1, shade * thickness / character_thickness)
+	local hl_group_index = round(shade * config.color_levels)
+	if hl_group_index == 0 then return end
+
+	local character_list = VERTICAL_BARS
+	local hl_group = color.get_hl_group({ level = hl_group_index })
+
+	return character_index, character_list, hl_group
+end
+
 local function get_left_block_properties(micro_shift, thickness, shade)
 	local character_index = math.ceil(micro_shift)
 	if character_index == 0 then return end
@@ -294,7 +310,11 @@ local function draw_horizontally_shifted_sub_block(row, col_left, col_right, sha
 	local gap_left = col_left % 1
 	local gap_right = (1 - col_right) % 1
 
-	if math.max(gap_left, gap_right) / 2 < math.min(gap_left, gap_right) then
+	if config.legacy_computing_symbols_support and thickness <= 1.5 / 8 then
+		-- Draw vertical bar
+		local micro_shift = center * 8
+		character_index, character_list, hl_group = get_vertical_bar_properties(micro_shift, thickness, shade)
+	elseif math.max(gap_left, gap_right) / 2 < math.min(gap_left, gap_right) then
 		-- Draw alternating block
 		if bulge_above then
 			local micro_shift = (col_right % 1) * 8

--- a/lua/smear_cursor/events.lua
+++ b/lua/smear_cursor/events.lua
@@ -3,29 +3,55 @@ local config = require("smear_cursor.config")
 local screen = require("smear_cursor.screen")
 local M = {}
 
-local function get_cmd_row()
-	return vim.o.lines - vim.opt.cmdheight._value + 1
-end
+local latest_mode = nil
+local latest_row = nil
+local latest_col = nil
+local timer = nil
 
-local function move_cursor_cmd()
-	if not config.smear_to_cmd then return end
-	local row = get_cmd_row()
-	local col = vim.fn.getcmdpos() + 1
-	animation.change_target_position(row, col)
-end
+local EVENT_TRIGGER = nil
+local AFTER_DELAY = 1
 
-local function move_cursor()
-	if vim.api.nvim_get_mode().mode == "c" then
-		move_cursor_cmd()
+local function move_cursor(trigger)
+	trigger = trigger or EVENT_TRIGGER
+	local row, col
+	local mode = vim.api.nvim_get_mode().mode
+
+	if mode ~= "c" then
+		row, col = screen.get_screen_cursor_position()
+	elseif config.smear_to_cmd then
+		row, col = screen.get_screen_cmd_cursor_position()
 	else
-		local row, col = screen.get_screen_cursor_position()
+		return
+	end
+
+	if timer ~= nil and timer:is_active() then
+		timer:stop()
+		timer:close()
+	end
+
+	if trigger == AFTER_DELAY and mode == latest_mode and row == latest_row and col == latest_col then
 		animation.change_target_position(row, col)
+	else -- try until the cursor stops moving
+		latest_mode = mode
+		latest_row = row
+		latest_col = col
+
+		timer = vim.uv.new_timer()
+		timer:start(
+			config.delay_event_to_smear,
+			0,
+			vim.schedule_wrap(function()
+				move_cursor(AFTER_DELAY)
+			end)
+		)
 	end
 end
 
-M.move_cursor = function()
+M.move_cursor = function(trigger)
 	-- Must defer for screen.get_screen_cursor_position() and vim.api.nvim.get_mode()
-	vim.defer_fn(move_cursor, 0)
+	vim.defer_fn(function()
+		move_cursor(trigger)
+	end, 0)
 end
 
 local function jump_cursor()
@@ -37,9 +63,9 @@ M.jump_cursor = function()
 	vim.defer_fn(jump_cursor, 0) -- for screen.get_screen_cursor_position()
 end
 
-M.move_cursor_insert_mode = function()
+M.move_cursor_insert_mode = function(trigger)
 	if config.smear_insert_mode then
-		M.move_cursor()
+		M.move_cursor(trigger)
 	else
 		M.jump_cursor()
 	end
@@ -51,8 +77,8 @@ M.listen = function()
 		augroup SmearCursor
 			autocmd!
 			autocmd CursorMoved,CursorMovedI * lua require("smear_cursor.color").update_color_at_cursor()
-			autocmd CursorMoved,ModeChanged,WinScrolled * lua require("smear_cursor.events").move_cursor()
-			autocmd CursorMovedI * lua require("smear_cursor.events").move_cursor_insert_mode()
+			autocmd CursorMoved,ModeChanged,WinScrolled * lua require("smear_cursor.events").move_cursor(nil)
+			autocmd CursorMovedI * lua require("smear_cursor.events").move_cursor_insert_mode(nil)
 			autocmd ColorScheme * lua require("smear_cursor.color").clear_cache()
 		augroup END
 	]],

--- a/lua/smear_cursor/events.lua
+++ b/lua/smear_cursor/events.lua
@@ -37,6 +37,14 @@ M.jump_cursor = function()
 	vim.defer_fn(jump_cursor, 0) -- for screen.get_screen_cursor_position()
 end
 
+M.move_cursor_insert_mode = function()
+	if config.smear_insert_mode then
+		M.move_cursor()
+	else
+		M.jump_cursor()
+	end
+end
+
 M.listen = function()
 	vim.api.nvim_exec2(
 		[[
@@ -44,7 +52,7 @@ M.listen = function()
 			autocmd!
 			autocmd CursorMoved,CursorMovedI * lua require("smear_cursor.color").update_color_at_cursor()
 			autocmd CursorMoved,ModeChanged,WinScrolled * lua require("smear_cursor.events").move_cursor()
-			autocmd CursorMovedI * lua require("smear_cursor.events").jump_cursor()
+			autocmd CursorMovedI * lua require("smear_cursor.events").move_cursor_insert_mode()
 			autocmd ColorScheme * lua require("smear_cursor.color").clear_cache()
 		augroup END
 	]],

--- a/lua/smear_cursor/screen.lua
+++ b/lua/smear_cursor/screen.lua
@@ -16,6 +16,13 @@ M.get_screen_cursor_position = function()
 	return row, col
 end
 
+M.get_screen_cmd_cursor_position = function()
+	local row = vim.o.lines - vim.opt.cmdheight._value + 1
+	local col = vim.fn.getcmdpos() + 1
+
+	return row, col
+end
+
 M.get_screen_distance = function(row_start, row_end)
 	local reversed = false
 


### PR DESCRIPTION
Add smear animations in insert mode (enabled by default). Accounts for transitions between normal and insert mode.

## Changes

- add smear in insert mode
- add configuration options (behavior and animation settings) for insert mode
- add vertical bar characters (for fonts supporting legacy computing symbols)
- add a duration the cursor must stay still before triggering animation: `delay_event_to_smear`, default 1 millisecond


## Related GitHub issues and pull requests

- fix #72 
