### PR TITLE
fix: noice.nvim getting cmdline_pos results in nil value

### DIFF
--- a/lua/smear_cursor/screen.lua
+++ b/lua/smear_cursor/screen.lua
@@ -18,8 +18,8 @@ end
 
 M.get_screen_cmd_cursor_position = function()
 	if vim.g.ui_cmdline_pos ~= nil then
-		local row = vim.g.ui_cmdline_pos[1]
-		local col = vim.g.ui_cmdline_pos[2] + vim.fn.getcmdpos() + 1
+		local row = vim.g.ui_cmdline_pos["row"]
+		local col = vim.g.ui_cmdline_pos["col"] + vim.fn.getcmdpos() + 1
 
 		return row, col
 	end


### PR DESCRIPTION
In the latest update (v0.4.0), opening `noice.nvim`'s command_palette will results in following error:

```
Error executing vim.schedule lua callback: .../nvim/lazy/smear-cursor.nvim/lua/smear_cursor/screen.lua:22: attempt to perform arithmetic on a nil value
stack traceback:
	.../nvim/lazy/smear-cursor.nvim/lua/smear_cursor/screen.lua:22: in function 'get_screen_cmd_cursor_position'
	.../nvim/lazy/smear-cursor.nvim/lua/smear_cursor/events.lua:24: in function 'move_cursor'
	.../nvim/lazy/smear-cursor.nvim/lua/smear_cursor/events.lua:59: in function ''
	vim/_editor.lua: in function ''
	vim/_editor.lua: in function <vim/_editor.lua:0>
```

I traced back to commit 2d6fa78 which introduced this problem. 

## Changes

change: accessing `vim.g.ui_cmdline_pos` using string instead of index