### PR TITLE
feat: use vim.o.guicursor to hide real cursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ As an example of further configuration, you can tune the smear dynamics to be sn
     stiffness = 0.8,               -- 0.6      [0, 1]
     trailing_stiffness = 0.5,      -- 0.3      [0, 1]
     distance_stop_animating = 0.5, -- 0.1      > 0
-    hide_target_hack = false,      -- true     boolean
   },
 ```
 
@@ -117,6 +116,7 @@ As an example of further configuration, you can tune the smear dynamics to be sn
 >     stiffness = 0.3,
 >     trailing_stiffness = 0.1,
 >     trailing_exponent = 5,
+>     hide_target_hack = true,
 >     gamma = 1,
 >   }
 > ```

--- a/lua/smear_cursor/animation.lua
+++ b/lua/smear_cursor/animation.lua
@@ -31,12 +31,21 @@ local function cursor_is_vertical_bar()
 	end
 end
 
+local function cursor_is_horizontal_bar()
+	return vim.api.nvim_get_mode().mode == "R" and config.horizontal_bar_cursor_replace_mode
+end
+
 local function set_corners(corners, row, col)
-	corners[1] = { row, col }
 	if cursor_is_vertical_bar() then
+		corners[1] = { row, col }
 		corners[2] = { row, col + 1 / 8 }
 		corners[3] = { row + 1, col + 1 / 8 }
+	elseif cursor_is_horizontal_bar() then
+		corners[1] = { row + 7 / 8, col }
+		corners[2] = { row + 7 / 8, col + 1 }
+		corners[3] = { row + 1, col + 1 }
 	else
+		corners[1] = { row, col }
 		corners[2] = { row, col + 1 }
 		corners[3] = { row + 1, col + 1 }
 	end

--- a/lua/smear_cursor/color.lua
+++ b/lua/smear_cursor/color.lua
@@ -185,4 +185,9 @@ setmetatable(M, {
 	end,
 })
 
+vim.api.nvim_set_hl(0, "SmearCursorHidden", {
+	fg = "white",
+	blend = 100,
+})
+
 return M

--- a/lua/smear_cursor/config.lua
+++ b/lua/smear_cursor/config.lua
@@ -36,6 +36,12 @@ M.smear_insert_mode = true
 -- Set to `true` if your cursor is a vertical bar in insert mode.
 M.vertical_bar_cursor_insert_mode = true
 
+-- Smear cursor in replace mode.
+M.smear_replace_mode = false
+
+-- Set to `true` if your cursor is a horizontal bar in replace mode.
+M.horizontal_bar_cursor_replace_mode = true
+
 -- Attempt to hide the real cursor by drawing a character below it.
 -- Can be useful when not using `termguicolors`
 M.hide_target_hack = false

--- a/lua/smear_cursor/config.lua
+++ b/lua/smear_cursor/config.lua
@@ -37,7 +37,8 @@ M.smear_insert_mode = true
 M.vertical_bar_cursor_insert_mode = true
 
 -- Attempt to hide the real cursor by drawing a character below it.
-M.hide_target_hack = true
+-- Can be useful when not using `termguicolors`
+M.hide_target_hack = false
 
 -- Number of windows that stay open for rendering.
 M.max_kept_windows = 50
@@ -82,8 +83,8 @@ M.slowdown_exponent = 0
 M.distance_stop_animating = 0.1
 
 -- Set of parameters for insert mode
-M.stiffness_insert_mode = 0.4
-M.trailing_stiffness_insert_mode = 0.4
+M.stiffness_insert_mode = 0.3
+M.trailing_stiffness_insert_mode = 0.3
 M.trailing_exponent_insert_mode = 1
 M.distance_stop_animating_vertical_bar = 0.875 -- Can be decreased (e.g. to 0.1) if using legacy computing symbols
 

--- a/lua/smear_cursor/events.lua
+++ b/lua/smear_cursor/events.lua
@@ -19,6 +19,8 @@ local function move_cursor(trigger, jump)
 	local row, col
 	local mode = vim.api.nvim_get_mode().mode
 
+	if mode == "R" and not config.smear_replace_mode then jump = true end
+
 	if mode ~= "c" then
 		row, col = screen.get_screen_cursor_position()
 	elseif config.smear_to_cmd then


### PR DESCRIPTION
Use `vim.o.guicursor` to hide the real cursor, instead of printing a block character at the target location.

## Changes

- change `hide_target_hack` to `false` by default. May be set to `true` for non-users of `termguicolors`
- fix visible smear in replace mode
