### PR TITLE
fix(events): clear augroup instead of deleting

### DIFF
--- a/lua/smear_cursor/events.lua
+++ b/lua/smear_cursor/events.lua
@@ -121,7 +121,7 @@ M.listen = function()
 end
 
 M.unlisten = function()
-	vim.api.nvim_del_augroup_by_name("SmearCursor")
+	vim.api.nvim_clear_autocmds({ group = "SmearCursor" })
 	vim.on_key(nil, cursor_namespace)
 end
 


### PR DESCRIPTION
fixes #99 

Looks like this occurs when jumping from one ignored buffer to another (or if the event fires twice?).

The group is already deleted, so it attempts to delete it again, resulting in the error. 

~~The fix is to check whether the group exists first with `pcall` before deleting.~~

We can use the `nvim_clear_autocmds` API in place of deleting to resolve this. Even if no autocmds are removed, no error will occur.