### PR TITLE
fix: interaction with other plugins modifying vim.o.guicursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,13 @@ If you are not using `termguicolors`, you need to manually set a color gradient 
   }
 ```
 
+If you are not using `guicursor`, and you notice the cursor getting duplicated (smear visible at the same time as the _real_ cursor), try setting
+```lua
+  opts = {
+    hide_target_hack = true,
+  }
+```
+
 </details>
 
 

--- a/lua/smear_cursor/animation.lua
+++ b/lua/smear_cursor/animation.lua
@@ -20,9 +20,6 @@ local current_top_row = -1
 local previous_line = -1
 local current_line = -1
 
-local original_guicursor = nil
-local cursor_hidden = false
-
 local function cursor_is_vertical_bar()
 	if vim.api.nvim_get_mode().mode == "i" then
 		return config.vertical_bar_cursor_insert_mode
@@ -178,23 +175,17 @@ local function stop_animation()
 	animating = false
 end
 
-local function hide_cursor()
+local function hide_real_cursor()
 	if not config.hide_target_hack then
-		if cursor_hidden or vim.o.guicursor == "a:NeoscrollHiddenCursor" then return end
-		original_guicursor = vim.o.guicursor
-		cursor_hidden = true
-		vim.o.guicursor = "a:SmearCursorHidden"
+		color.hide_real_cursor()
 	elseif not cursor_is_vertical_bar() then
 		local character = "█"
 		draw.draw_character(target_position[1], target_position[2], character, color.get_hl_group())
 	end
 end
 
-local function unhide_cursor()
-	if not cursor_hidden then return end
-	cursor_hidden = false
-
-	vim.o.guicursor = original_guicursor
+local function unhide_real_cursor()
+	if not config.hide_target_hack then color.unhide_real_cursor() end
 end
 
 local function animate()
@@ -222,7 +213,7 @@ local function animate()
 	then
 		set_corners(current_corners, target_position[1], target_position[2])
 		if vim.api.nvim_get_mode().mode == "c" then vim.cmd.redraw() end
-		unhide_cursor()
+		unhide_real_cursor()
 		stop_animation()
 		return
 	end
@@ -249,9 +240,9 @@ local function animate()
 	end
 
 	if target_reached then
-		unhide_cursor()
+		unhide_real_cursor()
 	else
-		hide_cursor()
+		hide_real_cursor()
 	end
 
 	draw.draw_quad(drawn_corners, target_position, cursor_is_vertical_bar())
@@ -366,7 +357,7 @@ M.change_target_position = function(row, col)
 	set_corners(target_corners, row, col)
 	set_stiffnesses()
 
-	hide_cursor()
+	hide_real_cursor()
 	start_anination()
 end
 

--- a/lua/smear_cursor/color.lua
+++ b/lua/smear_cursor/color.lua
@@ -185,9 +185,24 @@ setmetatable(M, {
 	end,
 })
 
-vim.api.nvim_set_hl(0, "SmearCursorHidden", {
-	fg = "white",
-	blend = 100,
-})
+-- Make the real cursor hideable
+if type(vim.o.guicursor) == "string" then
+	if vim.o.guicursor ~= "" then vim.o.guicursor = vim.o.guicursor .. "," end
+	vim.o.guicursor = vim.o.guicursor .. "a:SmearCursorHideable"
+end
+
+M.hide_real_cursor = function()
+	vim.api.nvim_set_hl(0, "SmearCursorHideable", {
+		fg = "white",
+		blend = 100,
+	})
+end
+
+M.unhide_real_cursor = function()
+	vim.api.nvim_set_hl(0, "SmearCursorHideable", {
+		fg = "none",
+		blend = 0,
+	})
+end
 
 return M


### PR DESCRIPTION
Only append a hl group to `vim.o.guicursor` instead of hard setting it. Should fix bad interactions with other plugins changing its value.


## Related GitHub issues and pull requests

- fix #101 
