### PR TITLE
feat: terminal mode toggler

### DIFF
--- a/lua/smear_cursor/config.lua
+++ b/lua/smear_cursor/config.lua
@@ -69,7 +69,7 @@ M.time_interval = 17 -- milliseconds
 M.delay_event_to_smear = 1 -- milliseconds
 
 -- Delay for `vim.on_key` to avoid redundancy with vim events triggers.
-M.delay_after_key = 1 -- milliseconds
+M.delay_after_key = 5 -- milliseconds
 
 -- Smear configuration ---------------------------------------------------------
 

--- a/lua/smear_cursor/config.lua
+++ b/lua/smear_cursor/config.lua
@@ -39,6 +39,10 @@ M.vertical_bar_cursor_insert_mode = true
 -- Smear cursor in replace mode.
 M.smear_replace_mode = false
 
+-- Smear cursor in terminal mode.
+-- If the smear goes to the wrong location when enabled, try increasing `delay_after_key`.
+M.smear_terminal_mode = false
+
 -- Set to `true` if your cursor is a horizontal bar in replace mode.
 M.horizontal_bar_cursor_replace_mode = true
 

--- a/lua/smear_cursor/events.lua
+++ b/lua/smear_cursor/events.lua
@@ -20,6 +20,7 @@ local function move_cursor(trigger, jump)
 	local mode = vim.api.nvim_get_mode().mode
 
 	if mode == "R" and not config.smear_replace_mode then jump = true end
+	if mode == "t" and not config.smear_terminal_mode then jump = true end
 
 	if mode ~= "c" then
 		row, col = screen.get_screen_cursor_position()


### PR DESCRIPTION
Add option `smear_terminal_mode` to toggle smear in terminal mode.

## Changes

- disable smear in terminal mode by default
- change default `delay_after_key` from 1ms to 5ms


## Related GitHub issues and pull requests

- fix #105 
- fix #106
