### PR TITLE
feat: add toggles for smear directions

### DIFF
--- a/lua/smear_cursor/animation.lua
+++ b/lua/smear_cursor/animation.lua
@@ -333,10 +333,12 @@ M.change_target_position = function(row, col)
 			not animating
 			and (
 				(not config.smear_between_neighbor_lines and math.abs(row - target_position[1]) <= 1)
-				or (
-					math.abs(row - target_position[1]) < config.min_vertical_distance_smear
-					and math.abs(col - target_position[2]) < config.min_horizontal_distance_smear
-				)
+				or (math.abs(row - target_position[1]) < config.min_vertical_distance_smear and math.abs(
+					col - target_position[2]
+				) < config.min_horizontal_distance_smear)
+				or (not config.smear_horizontally and row == target_position[1])
+				or (not config.smear_vertically and col == target_position[2])
+				or (not config.smear_diagonally and row ~= target_position[1] and col ~= target_position[2])
 			)
 		then
 			M.jump(row, col)

--- a/lua/smear_cursor/config.lua
+++ b/lua/smear_cursor/config.lua
@@ -16,6 +16,11 @@ M.smear_between_neighbor_lines = true
 M.min_horizontal_distance_smear = 0
 M.min_vertical_distance_smear = 0
 
+-- Toggles for directions
+M.smear_horizontally = true
+M.smear_vertically = true
+M.smear_diagonally = true -- Neither horizontal nor vertical
+
 -- Smear cursor when entering or leaving command line mode
 M.smear_to_cmd = true
 


### PR DESCRIPTION
Add toggles for smear directions:
- `smear_horizontally` (default `true`)
- `smear_vertically` (default `true`)
- `smear_diagonally` (default `true`)


## Related GitHub issues and pull requests

- may fix #112 
