### PR TITLE
fix: prevent disabled smears when moving in fast succession

### DIFF
--- a/lua/smear_cursor/animation.lua
+++ b/lua/smear_cursor/animation.lua
@@ -330,18 +330,25 @@ M.change_target_position = function(row, col)
 	if current_window_id == previous_window_id and current_buffer_id == previous_buffer_id then
 		if config.scroll_buffer_space then scroll_buffer_space() end
 		if
-			not animating
-			and (
-				(not config.smear_between_neighbor_lines and math.abs(row - target_position[1]) <= 1)
-				or (math.abs(row - target_position[1]) < config.min_vertical_distance_smear and math.abs(
-					col - target_position[2]
-				) < config.min_horizontal_distance_smear)
-				or (not config.smear_horizontally and row == target_position[1])
-				or (not config.smear_vertically and col == target_position[2])
-				or (not config.smear_diagonally and row ~= target_position[1] and col ~= target_position[2])
+			(not config.smear_between_neighbor_lines and math.abs(row - current_corners[1][1]) <= 1.5)
+			or (
+				math.abs(row - current_corners[1][1]) < config.min_vertical_distance_smear
+				and math.abs(col - current_corners[1][2]) < config.min_horizontal_distance_smear
+			)
+			or (not config.smear_horizontally and math.abs(row - current_corners[1][1]) <= 0.5)
+			or (not config.smear_vertically and math.abs(col - current_corners[1][2]) <= 0.5)
+			or (
+				not config.smear_diagonally
+				and math.abs(row - current_corners[1][1]) > 0.5
+				and math.abs(col - current_corners[1][2]) > 0.5
 			)
 		then
+			if animating then
+				unhide_real_cursor()
+				stop_animation()
+			end
 			M.jump(row, col)
+			if vim.api.nvim_get_mode().mode == "c" then vim.cmd.redraw() end
 			return
 		end
 	else


### PR DESCRIPTION
Prevent smearing when disabled in config, even when moving in fast succession.
May not work perfectly as intended yet (sometimes, the smear does not trigger even if it should).
Affected options:
- `smear_between_neighbor_lines`
- `min_vertical_distance_smear`
- `min_horizontal_distance_smear`
- `smear_horizontally`
- `smear_vertically`
- `smear_diagonally`