### PR TITLE
🐛 Bug(smear-cursor): explicitly set border of floating window

### DIFF
--- a/lua/smear_cursor/draw.lua
+++ b/lua/smear_cursor/draw.lua
@@ -63,7 +63,7 @@ local function get_window(tab, row, col)
 
 		if vim.api.nvim_win_is_valid(wb.window_id) and vim.api.nvim_buf_is_valid(wb.buffer_id) then
 			---@type vim.api.keyset.win_config
-			local window_config = { relative = "editor", row = row - 1, col = col - 1 }
+			local window_config = { relative = "editor", border = "none", row = row - 1, col = col - 1 }
 			if can_hide then window_config.hide = false end
 			vim.api.nvim_win_set_config(wb.window_id, window_config)
 			return wb.window_id, wb.buffer_id


### PR DESCRIPTION
Setting the border to "none" for the float prevents issues if the user changes the default border with `:set winborder`

By explicitly setting the border to "none" it prevents weird (ugly) behavior when the default border is changed with the new `winborder` option. This won't negatively affect older neovim versions and avoids ugliness if the user runs `:set winborder=rounded` (vim.o.winborder = "rounded") or any other border type than "none".

This `winborder` option was just recently merged in neovim nightly, just hoping to get ahead of it :)

## Changes

- add `border = "none" to the `window_config` on [this line](https://github.com/sphamba/smear-cursor.nvim/blob/main/lua/smear_cursor/draw.lua#L66)