### PR TITLE
feat: smooth block cursor without smear

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,21 @@ As an example of further configuration, you can tune the smear dynamics to be sn
 </details>
 
 <details>
+<summary>█ Smooth cursor without smear</summary>
+
+If you wish to only have a smoother cursor that keeps its rectangular shape (without the trail), you can set the following options:
+
+```lua
+  opts = {
+    stiffness = 0.5,
+    trailing_stiffness = 0.49,
+    never_draw_over_target = false,
+  },
+```
+
+</details>
+
+<details>
 <summary>🌌 Transparent background</summary>
 
 Drawing the smear over a transparent background works better when using a font that supports legacy computing symbols, therefore setting the following option:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ This plugin is intended for terminals/GUIs that can only display text and do not
 
 [Demo](https://private-user-images.githubusercontent.com/17217484/389300116-fc95b4df-d791-4c53-9141-4f870eb03ab2.mp4?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MzI0NzY0NDAsIm5iZiI6MTczMjQ3NjE0MCwicGF0aCI6Ii8xNzIxNzQ4NC8zODkzMDAxMTYtZmM5NWI0ZGYtZDc5MS00YzUzLTkxNDEtNGY4NzBlYjAzYWIyLm1wND9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDExMjQlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQxMTI0VDE5MjIyMFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTg1NjFhZjJlODQ4YmU2NjAzY2EzY2I3NWMzMzI5MWQ1Njk2MTExYmEwYmExNTMwMThmYTJjYjE2ZjIyOThjNjMmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.Skw2VVyVWVkMe4ht6mvl_AZ_6QasJm8O6qsIZmcQ2XE)
 
+Some configuration examples:
+
+| Default | Faster |
+| --- | --- |
+| ![Image](https://github.com/user-attachments/assets/8d4ea0e6-6764-48ce-a182-7f1a63ffd762) | ![Image](https://github.com/user-attachments/assets/6c2ae042-55df-48a3-8e18-57517dc06633) |
+
+| Smooth cursor without smear | Fire hazard |
+| --- | --- |
+| ![Image](https://github.com/user-attachments/assets/47950a0c-2bbe-4148-b633-fea6d5e1f985) | ![Image](https://github.com/user-attachments/assets/ba847071-f918-4e8f-ae74-169a31e05368) |
+
 <!-- panvimdoc-ignore-end -->
 
 
@@ -94,6 +104,9 @@ Refer to [`lua/smear_cursor/config.lua`](https://github.com/sphamba/smear-cursor
 
 
 ### Examples
+
+> [!TIP]
+> See videos at the top for visual examples.
 
 <details>
 <summary>🔥 Faster smear</summary>

--- a/lua/smear_cursor/animation.lua
+++ b/lua/smear_cursor/animation.lua
@@ -239,7 +239,7 @@ local function animate()
 		end
 	end
 
-	if target_reached then
+	if target_reached and config.never_draw_over_target then
 		unhide_real_cursor()
 	else
 		hide_real_cursor()

--- a/lua/smear_cursor/config.lua
+++ b/lua/smear_cursor/config.lua
@@ -51,6 +51,9 @@ M.smear_terminal_mode = false
 -- Set to `true` if your cursor is a horizontal bar in replace mode.
 M.horizontal_bar_cursor_replace_mode = true
 
+-- Set to `false` to allow the smear to overlap the target character, hiding it until the animation is over.
+M.never_draw_over_target = true
+
 -- Attempt to hide the real cursor by drawing a character below it.
 -- Can be useful when not using `termguicolors`
 M.hide_target_hack = false
@@ -84,7 +87,7 @@ M.stiffness = 0.6
 
 -- How fast the smear's tail moves towards the target.
 -- 0: no movement, 1: instantaneous
-M.trailing_stiffness = 0.3
+M.trailing_stiffness = 0.4
 
 -- Controls if middle points are closer to the head or the tail.
 -- < 1: closer to the tail, > 1: closer to the head
@@ -98,8 +101,8 @@ M.slowdown_exponent = 0
 M.distance_stop_animating = 0.1
 
 -- Set of parameters for insert mode
-M.stiffness_insert_mode = 0.3
-M.trailing_stiffness_insert_mode = 0.3
+M.stiffness_insert_mode = 0.4
+M.trailing_stiffness_insert_mode = 0.4
 M.trailing_exponent_insert_mode = 1
 M.distance_stop_animating_vertical_bar = 0.875 -- Can be decreased (e.g. to 0.1) if using legacy computing symbols
 

--- a/lua/smear_cursor/draw.lua
+++ b/lua/smear_cursor/draw.lua
@@ -559,7 +559,14 @@ M.draw_quad = function(corners, target_position, vertical_bar)
 
 		for col = math.max(G.left, math.floor(left)), math.min(G.right, math.ceil(right)) do
 			-- Check if on target
-			if not vertical_bar and row == target_position[1] and col == target_position[2] then goto continue end
+			if
+				config.never_draw_over_target
+				and not vertical_bar
+				and row == target_position[1]
+				and col == target_position[2]
+			then
+				goto continue
+			end
 
 			local intersections = {}
 			for i = 1, 4 do


### PR DESCRIPTION
Add configuration option allowing to get a smooth block cursor the trail.

## Changes

- add `never_draw_over_target` option (default `true`)
- add videos in readme
