### PR TITLE
fix: #148 Define the border option as 'none' to impede the creation of windows with borders

### DIFF
--- a/lua/smear_cursor/draw.lua
+++ b/lua/smear_cursor/draw.lua
@@ -86,6 +86,7 @@ local function get_window(tab, row, col)
 		width = 1,
 		height = 1,
 		style = "minimal",
+		border = "none",
 		focusable = false,
 		noautocmd = true,
 		zindex = config.windows_zindex,


### PR DESCRIPTION
- fix #148