### PR TITLE
feat: add longitudinal gradient

### DIFF
--- a/lua/smear_cursor/config.lua
+++ b/lua/smear_cursor/config.lua
@@ -126,6 +126,7 @@ M.min_shade_no_diagonal_vertical_bar = 0.5
 
 M.color_levels = 16 -- Minimum 1, don't set manually if using cterm_cursor_colors
 M.gamma = 2.2 -- For color blending
+M.gradient_exponent = 1.0 -- For longitudinal gradient. 0: no gradient, 1: linear, ...
 M.max_shade_no_matrix = 0.75 -- 0: more overhangs, 1: more matrices
 M.matrix_pixel_threshold = 0.7 -- 0: all pixels, 1: no pixel
 M.matrix_pixel_threshold_vertical_bar = 0.25 -- 0: all pixels, 1: no pixel

--- a/tests/test_draw_quad.lua
+++ b/tests/test_draw_quad.lua
@@ -271,3 +271,24 @@ for i = 8, 0, -1 do
 
 	col = col + 5
 end
+
+-- Gradient
+
+row = 42
+col = 2
+
+draw.draw_quad({
+	{ row, col },
+	{ row, col + 16 },
+	{ row + 1, col + 16 },
+	{ row + 1, col },
+})
+
+row = row + 1
+
+draw.draw_quad({
+	{ row, col },
+	{ row, col + 16 },
+	{ row + 1, col + 16 },
+	{ row + 1, col },
+}, nil, nil, { row, col }, { 0, 1 / 16 })


### PR DESCRIPTION
Add gradient along smear direction.

- add `gradient_exponent` parameter, default to 1 (0: no gradient, 1: linear, ...)


<img width="133" height="48" alt="2025-11-17-001601_hyprshot" src="https://github.com/user-attachments/assets/c789fd74-646f-430e-9e76-a137c00c0da7" />